### PR TITLE
Fix team membership check using GraphQL API

### DIFF
--- a/src/policyengine_github_bot/webhooks.py
+++ b/src/policyengine_github_bot/webhooks.py
@@ -14,7 +14,7 @@ from policyengine_github_bot.github_auth import (
     get_github_client,
     get_installation_token,
     get_review_threads,
-    is_user_authorized,
+    is_user_authorized_async,
     reply_to_review_thread,
     resolve_review_thread,
 )
@@ -208,7 +208,7 @@ async def handle_issue_event(data: dict):
         return
 
     # Check authorization before invoking Claude Code
-    if not is_user_authorized(payload.installation.id, sender):
+    if not await is_user_authorized_async(payload.installation.id, sender):
         logfire.info(f"{prefix} - unauthorized user @{sender}, skipping Claude Code")
         github = get_github_client(payload.installation.id)
         gh_repo = github.get_repo(repo)
@@ -280,7 +280,7 @@ async def handle_issue_comment_event(data: dict):
     # If this is a PR and we're mentioned, use Claude Code (flexible - can review, commit, etc.)
     if is_pr and mentioned:
         # Check authorization before invoking Claude Code
-        if not is_user_authorized(payload.installation.id, commenter):
+        if not await is_user_authorized_async(payload.installation.id, commenter):
             logfire.info(f"{prefix} - unauthorized user @{commenter}, skipping Claude Code")
             github = get_github_client(payload.installation.id)
             gh_repo = github.get_repo(repo)
@@ -296,7 +296,7 @@ async def handle_issue_comment_event(data: dict):
 
     # Otherwise handle as a normal issue comment
     # Check authorization if mentioned (which triggers Claude Code)
-    if mentioned and not is_user_authorized(payload.installation.id, commenter):
+    if mentioned and not await is_user_authorized_async(payload.installation.id, commenter):
         logfire.info(f"{prefix} - unauthorized user @{commenter}, skipping Claude Code")
         github = get_github_client(payload.installation.id)
         gh_repo = github.get_repo(repo)
@@ -576,7 +576,7 @@ async def handle_pull_request_event(data: dict):
                 logfire.error(f"{prefix} - no installation ID")
                 return
 
-            if not is_user_authorized(payload.installation.id, sender):
+            if not await is_user_authorized_async(payload.installation.id, sender):
                 logfire.info(f"{prefix} - unauthorized user @{sender}, skipping review")
                 github = get_github_client(payload.installation.id)
                 gh_repo = github.get_repo(repo)
@@ -597,7 +597,7 @@ async def handle_pull_request_event(data: dict):
                 logfire.error(f"{prefix} - no installation ID")
                 return
 
-            if not is_user_authorized(payload.installation.id, sender):
+            if not await is_user_authorized_async(payload.installation.id, sender):
                 logfire.info(f"{prefix} - unauthorized user @{sender}, skipping review")
                 github = get_github_client(payload.installation.id)
                 gh_repo = github.get_repo(repo)

--- a/tests/test_github_auth.py
+++ b/tests/test_github_auth.py
@@ -1,0 +1,138 @@
+"""Tests for GitHub authentication and authorization."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from policyengine_github_bot.github_auth import is_user_authorized_async
+
+
+class TestIsUserAuthorizedAsync:
+    @pytest.mark.asyncio
+    async def test_authorized_user_returns_true(self):
+        """Test that a team member is authorized."""
+        mock_response = {
+            "data": {
+                "organization": {
+                    "team": {
+                        "members": {
+                            "nodes": [{"login": "nikhilwoodruff"}]
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch(
+            "policyengine_github_bot.github_auth.graphql_request",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            result = await is_user_authorized_async(12345, "nikhilwoodruff")
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_returns_false(self):
+        """Test that a non-team member is not authorized."""
+        mock_response = {
+            "data": {
+                "organization": {
+                    "team": {
+                        "members": {
+                            "nodes": []  # User not in results
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch(
+            "policyengine_github_bot.github_auth.graphql_request",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            result = await is_user_authorized_async(12345, "randomuser")
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_username_match(self):
+        """Test that username matching is case-insensitive."""
+        mock_response = {
+            "data": {
+                "organization": {
+                    "team": {
+                        "members": {
+                            "nodes": [{"login": "NikhilWoodruff"}]
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch(
+            "policyengine_github_bot.github_auth.graphql_request",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            result = await is_user_authorized_async(12345, "nikhilwoodruff")
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_null_team_returns_false(self):
+        """Test that null team data (no permission) returns false."""
+        mock_response = {
+            "data": {
+                "organization": {
+                    "team": None  # No permission to access team
+                }
+            }
+        }
+
+        with patch(
+            "policyengine_github_bot.github_auth.graphql_request",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            result = await is_user_authorized_async(12345, "nikhilwoodruff")
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_graphql_error_returns_false(self):
+        """Test that GraphQL errors fail closed (return false)."""
+        with patch(
+            "policyengine_github_bot.github_auth.graphql_request",
+            new_callable=AsyncMock,
+            side_effect=Exception("GraphQL error"),
+        ):
+            result = await is_user_authorized_async(12345, "nikhilwoodruff")
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_graphql_request_called_with_correct_params(self):
+        """Test that GraphQL request is called with correct parameters."""
+        mock_response = {
+            "data": {
+                "organization": {
+                    "team": {
+                        "members": {"nodes": []}
+                    }
+                }
+            }
+        }
+
+        with patch(
+            "policyengine_github_bot.github_auth.graphql_request",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_graphql:
+            await is_user_authorized_async(12345, "testuser")
+
+            mock_graphql.assert_called_once()
+            call_args = mock_graphql.call_args
+            assert call_args[0][0] == 12345  # installation_id
+            assert "organization" in call_args[0][1]  # query contains organization
+            assert call_args[0][2] == {
+                "org": "PolicyEngine",
+                "team": "core-developers",
+                "username": "testuser",
+            }


### PR DESCRIPTION
The REST API endpoint `org.get_team_by_slug()` requires `read:org` permission which the GitHub App didn't have, causing 404 errors when checking team membership.

Switched to using the GraphQL API which has better permission handling for team membership queries. The GraphQL query searches team members directly and works with the existing permissions.

Also made the authorization check async (`is_user_authorized_async`) since all call sites are already in async webhook handlers.